### PR TITLE
Update feed.xml

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -22,7 +22,7 @@
   <email>{{ site.owner.email }}</email>
 </author>
 {% for post in site.posts limit:20 %}
-
+{% assign author = site.authors[page.author] %}
 <entry>
   <title type="html"><![CDATA[{{ post.title | cdata_escape }}]]></title>
   <link rel="alternate" type="text/html" href="{% if post.link %}{{ post.link }}{% else %}{{ site_url }}{{ post.url }}{% endif %}"/>
@@ -32,9 +32,7 @@
   {% else %}<published>{{ post.date | date_to_xmlschema }}</published>
   <updated>{{ post.date | date_to_xmlschema }}</updated>{% endif %}
   <author>
-    <name>{{ site.owner.name }}</name>
-    <uri>{{ site_url }}</uri>
-    <email>{{ site.owner.email }}</email>
+    <name>{{ author.name }}</name>
   </author>
   {% for tag in post.tags %}<category scheme="{{ site_url }}/tags/#{{ tag | uri_escape }}" term="{{ tag }}" />{% endfor %}
   <content type="html">


### PR DESCRIPTION
fix #3 - Maintenant l'auteur n'est plus l'adresse générique mais le nom de l'auteur (besoin de mettre plus que le nom ? tiwtter, FB, mail?)